### PR TITLE
Add Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules
 var
 dist
+
+# Ignore all IDEA files
+*.iml
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM alpine:3.18.2
+
+# Volume for output
+VOLUME /output
+
+# Install dependencies
+RUN apk add --no-cache nodejs yarn zsh npm
+
+# Copy script and source
+COPY . /usr/src/apn-competency-helper
+COPY build-assets/run.sh /usr/src/run.sh
+RUN chmod +x /usr/src/run.sh
+
+# Build
+WORKDIR /usr/src/apn-competency-helper
+RUN yarn install
+RUN npm run-script build
+
+# Run
+CMD ["/usr/src/run.sh"]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ And finally, the helper zips everything in the `var` directory.
 
 ## Usage
 
+### Direct Execution on Local Machine
+
     //Install dependencies
     $ yarn install
 
@@ -62,7 +64,25 @@ Select the partner path
 
 ![Worksheet name](./doc/3.png)
 
-Look in the `var` directory!
+After execution of the script, the file structure is created in the `var` directory.
+
+
+### Execution Via Docker
+
+If you like to run this script within a contained environment, you can build a Docker image with
+
+    $ docker image rm -f aws-helper/apn-competency-helper && docker build -t aws-helper/apn-competency-helper .
+
+By specifying an output directory as a volume, you can run the competency helper like this:
+
+    $ docker run -it --name aws-competency-helper -v output:/output aws-helper/apn-competency-helper
+
+After execution of the script, the file structure is created in the `output` directory.
+
+To generate the file structure repeatedly, you can use the following command:
+
+    $ docker container start -i aws-competency-helper
+
 
 ## Troubleshoot
 

--- a/build-assets/run.sh
+++ b/build-assets/run.sh
@@ -1,0 +1,7 @@
+#!/bin/zsh
+
+cd apn-competency-helper
+
+node ./dist/index.js
+
+mv var/* /output


### PR DESCRIPTION
*Issue #, if available:*

This change will allow users to execute the was-competency-helper in an isolated and secure Docker container so that no change of the host system is necessary to run the helper.

*Description of changes:*

By adding a Dockerfile and an installation script, the user can now build a Docker image and run it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
